### PR TITLE
Fix usage of prefix as_ for something that allocate memory

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,7 +194,7 @@ impl Blocking {
         headers.get::<Self>().ok_or(()).map(|res| res.clone())
     }
 
-    fn as_string(&self) -> String {
+    fn to_string(&self) -> String {
         let mut out = String::new();
         let _ = write!(out, "{}", self.index);
         out
@@ -203,7 +203,7 @@ impl Blocking {
     fn add_to_uri(&self, uri: &Url) -> Url {
         let mut uri = uri.clone();
         uri.query_pairs_mut()
-            .append_pair("index", self.as_string().as_str())
+            .append_pair("index", self.to_string().as_str())
 
             .finish();
         uri


### PR DESCRIPTION
https://github.com/Gandi/rust-consul/blob/db264830ddae1bf4220b407a42f485f661d548e5/src/lib.rs#L197

The prefix `as_` is used for something that could be prefixed `to_`.

https://aturon.github.io/style/naming.html#conversions

As far as I see
maybe it should be a `as_str()` method and resturn a `&str` type.
